### PR TITLE
fix: ID選択機能のデプロイ環境での動作改善

### DIFF
--- a/components/panes/Map.vue
+++ b/components/panes/Map.vue
@@ -167,9 +167,10 @@ const onLeafletReady = (mapInstance: L.Map) => {
   
   // URLにIDが指定されている場合、その位置を中心に表示
   if (query.id) {
-    setTimeout(() => {
-      const id = query.id as string;
-      if (featuresMap.value[id]) {
+    const id = query.id as string;
+    // featuresMapが準備できるまで監視
+    const checkFeature = () => {
+      if (Object.keys(featuresMap.value).length > 0 && featuresMap.value[id]) {
         const feature = featuresMap.value[id];
         if (feature.geometry?.coordinates) {
           // GeoJSONの座標は[longitude, latitude]の順序
@@ -181,8 +182,13 @@ const onLeafletReady = (mapInstance: L.Map) => {
             zoom_.value = 15; // デフォルトで詳細表示
           }
         }
+      } else {
+        // まだ準備できていない場合は再試行
+        setTimeout(checkFeature, 100);
       }
-    }, 500); // featuresMapが更新されるまで待つ
+    };
+    // 初回実行を少し遅延
+    setTimeout(checkFeature, 100);
   }
   
   // 初期化完了後、URL更新を一度実行

--- a/components/panes/Osd.vue
+++ b/components/panes/Osd.vue
@@ -139,8 +139,9 @@ onMounted(async () => {
     // 選択IDの復元と中心表示
     if (query.id) {
       const id = query.id as string;
-      setTimeout(() => {
-        if (featuresMap.value[id]) {
+      // featuresMapが準備できるまで監視
+      const checkFeature = () => {
+        if (Object.keys(featuresMap.value).length > 0 && featuresMap.value[id]) {
           const feature = featuresMap.value[id];
           
           // 画像上でその位置を中心に表示
@@ -151,8 +152,16 @@ onMounted(async () => {
             viewer.viewport.panTo(point);
           }
           
-          // アノテーションが表示されている場合は選択状態にする
-          if (showAnnotations.value) {
+          // IDが指定されている場合はアノテーションを自動表示
+          if (!showAnnotations.value) {
+            showAnnotations.value = true;
+            // アノテーション表示後に選択状態を設定
+            setTimeout(() => {
+              removeSelected();
+              setSelected(id);
+            }, 100);
+          } else {
+            // アノテーションが表示されている場合は選択状態にする
             removeSelected();
             setSelected(id);
           }
@@ -162,8 +171,13 @@ onMounted(async () => {
             type: "both", // 地図も更新するため
             id,
           };
+        } else {
+          // まだ準備できていない場合は再試行
+          setTimeout(checkFeature, 100);
         }
-      }, 500); // 初期化が完了するまで少し待つ
+      };
+      // 初回実行を少し遅延
+      setTimeout(checkFeature, 100);
     }
   });
 


### PR DESCRIPTION
## Summary
デプロイ環境でID選択機能が正しく動作しない問題を修正しました。

## 問題
- https://nakamura196.github.io/iiif_geo/ja?u=...&id=210001 のようなURLでアクセスしても、指定したIDの位置が選択・表示されない
- ローカル環境では動作するが、デプロイ環境では動作しない

## 修正内容
1. **データ読み込み待機の改善**
   - 固定のタイムアウト（500ms）から再帰的なチェックに変更
   - `featuresMap`が確実に読み込まれるまで待機

2. **アノテーション自動表示**
   - IDパラメータが指定されている場合、アノテーションを自動的に表示
   - 選択状態が見えるようにする

3. **選択状態の確実な設定**
   - アノテーション表示後に適切なタイミングで選択状態を設定

## テスト方法
1. デプロイ環境で `?id=XXX` パラメータ付きでアクセス
2. 指定したIDの位置が地図とビューアで中心に表示されることを確認
3. アノテーションが自動表示され、選択状態になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)